### PR TITLE
Added pipefail because otherwise the script does not exit properly (t…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 if [ -n "${PLUGIN_SSH_KEY}" ]; then
     echo "Adding SSH Key..."
     mkdir -p ~/.ssh/


### PR DESCRIPTION
…he last command in the pipe 'tee' would return exit code 0 without this change)